### PR TITLE
Agregar módulo de JSON canónico para transacciones

### DIFF
--- a/app/canonicalizer.py
+++ b/app/canonicalizer.py
@@ -1,0 +1,24 @@
+# app/canonicalizer.py
+import json
+from typing import Any, Dict
+
+
+def canonical_json(data: Dict[str, Any]) -> str:
+    """
+    JSON canónico:
+    - Llaves ordenadas lexicográficamente.
+    - Sin espacios extra.
+    """
+    return json.dumps(
+        data,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+
+
+def canonical_bytes(data: Dict[str, Any]) -> bytes:
+    """
+    JSON canónico codificado en UTF-8 (para firmar/verificar).
+    """
+    return canonical_json(data).encode("utf-8")


### PR DESCRIPTION
Implementa canonicalizer.py para generar representaciones JSON determinísticas, necesarias para el firmado Ed25519.

- Ordena las llaves lexicográficamente
- Elimina espacios innecesarios 
- Añade helper canonical_bytes() para flujo de firmado/verificación
- Base indispensable para la consistencia del hash previo a la firma